### PR TITLE
Fix update-vendor-firmware script

### DIFF
--- a/update-vendor-firmware
+++ b/update-vendor-firmware
@@ -3,7 +3,7 @@
 
 set -e
 
-VENDORFW=/boot/efi/vendorfw/
+VENDORFW=/boot/efi/vendor-fw/
 TARGET=/lib/firmware/
 TARGET_MANIFEST=".vendorfw.manifest"
 


### PR DESCRIPTION
The directory is called `vendor-fw` as per: https://github.com/AsahiLinux/asahi-installer/blob/a85b6c9ea67764e502e98198baf598422dd35a1e/src/osinstall.py