### PR TITLE
systemd: add missing install sections

### DIFF
--- a/systemd/systemd-udev-trigger-early.service
+++ b/systemd/systemd-udev-trigger-early.service
@@ -12,3 +12,6 @@ ConditionPathIsReadWrite=/sys
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=-udevadm trigger --type=devices --action=add --subsystem-match=block
+
+[Install]
+WantedBy=sysinit.target

--- a/systemd/update-vendor-firmware.service
+++ b/systemd/update-vendor-firmware.service
@@ -12,3 +12,6 @@ ConditionDirectoryNotEmpty=/boot/efi/vendorfw
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=update-vendor-firmware
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
Add an install section (matching what we do in the makefile), so that `systemctl enable` and systemd presets will work as expected.