### PR TITLE
Add dracut config for Fedora

### DIFF
--- a/dracut/10-asahi.conf
+++ b/dracut/10-asahi.conf
@@ -1,0 +1,25 @@
+# Modules necessary for using Linux on Apple Silicon Macs
+
+# For NVMe & SMC
+add_drivers+=" apple-mailbox "
+
+# For NVMe
+add_drivers+=" nvme_apple "
+
+# For USB and HID
+add_drivers+=" pinctrl-apple-gpio "
+
+# SMC core
+add_drivers+=" macsmc macsmc-rtkit "
+
+# For USB
+add_drivers+=" i2c-apple tps6598x apple-dart dwc3 dwc3-of-simple xhci-pci pcie-apple gpio_macsmc "
+
+# For HID
+add_drivers+=" spi-apple spi-hid-apple spi-hid-apple-of "
+
+# For RTC
+add_drivers+=" rtc-macsmc simple-mfd-spmi spmi-apple-controller nvmem_spmi_mfd "
+
+# For MTP HID
+add_drivers+=" apple-dockchannel dockchannel-hid apple-rtkit-helper "


### PR DESCRIPTION
Add a dracut config equivalent to the initcpio one.