### PR TITLE
update-vendor-firmware: Run using bash instead of posix sh.

### DIFF
--- a/update-vendor-firmware
+++ b/update-vendor-firmware
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # SPDX-License-Identifier: MIT
 
 set -e


### PR DESCRIPTION
Process subsitution and `source` are not supported in posix shells leading to an error when trying to run the script on Debian based distributions which use dash as default sh.

While process substitution is technically a ksh extension, explicitly running the script through bash solves the problem and should work on all supported distributions.