### PR TITLE
Various makefile fixes for Fedora

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PREFIX=/usr/local
 CONFIG_DIR=/etc/default
+BIN_DIR=$(PREFIX)/bin
 SCRIPTS=update-vendor-firmware update-m1n1
 ARCH_SCRIPTS=update-grub first-boot
 UNITS=first-boot.service
@@ -16,15 +17,15 @@ build/%: %
 	chmod +x "$@"
 
 install: all
-	install -d $(DESTDIR)$(PREFIX)/bin/
-	install -m0755 -t $(DESTDIR)$(PREFIX)/bin/ $(BUILD_SCRIPTS)
+	install -d $(DESTDIR)$(BIN_DIR)/
+	install -m0755 -t $(DESTDIR)$(BIN_DIR)/ $(BUILD_SCRIPTS)
 	install -dD $(DESTDIR)/etc
 	install -m0644 -t $(DESTDIR)/etc etc/m1n1.conf
 	install -dD $(DESTDIR)$(PREFIX)/share/asahi-scripts
 	install -m0644 -t $(DESTDIR)$(PREFIX)/share/asahi-scripts functions.sh
 
 install-arch: install
-	install -m0755 -t $(DESTDIR)$(PREFIX)/bin/ $(BUILD_ARCH_SCRIPTS)
+	install -m0755 -t $(DESTDIR)$(BIN_DIR)/ $(BUILD_ARCH_SCRIPTS)
 	install -dD $(DESTDIR)$(PREFIX)/lib/systemd/system
 	install -dD $(DESTDIR)$(PREFIX)/lib/systemd/system/{multi-user,sysinit}.target.wants
 	install -m0644 -t $(DESTDIR)$(PREFIX)/lib/systemd/system $(addprefix systemd/,$(UNITS))
@@ -42,12 +43,13 @@ install-fedora: install
 	install -m0644 -t $(DESTDIR)$(DRACUT_CONF_DIR) dracut/10-asahi.conf
 
 uninstall:
-	rm -f $(addprefix $(DESTDIR)$(PREFIX)/bin/,$(SCRIPTS))
-	rm -f $(addprefix $(DESTDIR)$(PREFIX)/lib/systemd/system/,$(UNITS))
-	rm -f $(addprefix $(DESTDIR)$(PREFIX)/lib/systemd/system/multi-user.target.wants/,$(MULTI_USER_WANTS))
+	rm -f $(addprefix $(DESTDIR)$(BIN_DIR)/,$(SCRIPTS))
 	rm -rf $(DESTDIR)$(PREFIX)/share/asahi-scripts
 
 uninstall-arch:
+	rm -f $(addprefix $(DESTDIR)$(BIN_DIR)/,$(ARCH_SCRIPTS))
+	rm -f $(addprefix $(DESTDIR)$(PREFIX)/lib/systemd/system/,$(UNITS))
+	rm -f $(addprefix $(DESTDIR)$(PREFIX)/lib/systemd/system/multi-user.target.wants/,$(MULTI_USER_WANTS))
 	rm -f $(DESTDIR)$(PREFIX)/lib/initcpio/install/asahi
 	rm -f $(DESTDIR)$(PREFIX)/lib/initcpio/hooks/asahi
 	rm -f $(DESTDIR)$(PREFIX)/share/libalpm/hooks/95-m1n1-install.hook

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ build/%: %
 	sed -e s,/etc/default,$(CONFIG_DIR),g "$<" > "$@"
 	chmod +x "$@"
 
+clean:
+	rm -rf build
+
 install: all
 	install -d $(DESTDIR)$(BIN_DIR)/
 	install -m0755 -t $(DESTDIR)$(BIN_DIR)/ $(BUILD_SCRIPTS)
@@ -57,4 +60,4 @@ uninstall-arch:
 uninstall-fedora:
 	rm -f $(DESTDIR)$(DRACUT_CONF_DIR)/10-asahi.conf
 
-.PHONY: install install-arch install-fedora uninstall uninstall-arch uninstall-fedora
+.PHONY: clean install install-arch install-fedora uninstall uninstall-arch uninstall-fedora

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 PREFIX=/usr/local
 CONFIG_DIR=/etc/default
-SCRIPTS=update-vendor-firmware update-grub first-boot update-m1n1
+SCRIPTS=update-vendor-firmware update-m1n1
+ARCH_SCRIPTS=update-grub first-boot
 UNITS=first-boot.service
 MULTI_USER_WANTS=first-boot.service
 DRACUT_CONF_DIR=$(PREFIX)/lib/dracut/dracut.conf.d
 BUILD_SCRIPTS=$(addprefix build/,$(SCRIPTS))
+BUILD_ARCH_SCRIPTS=$(addprefix build/,$(ARCH_SCRIPTS))
 
-all: $(BUILD_SCRIPTS)
+all: $(BUILD_SCRIPTS) $(BUILD_ARCH_SCRIPTS)
 
 build/%: %
 	@[ ! -e build ] && mkdir -p build || true
@@ -16,17 +18,18 @@ build/%: %
 install: all
 	install -d $(DESTDIR)$(PREFIX)/bin/
 	install -m0755 -t $(DESTDIR)$(PREFIX)/bin/ $(BUILD_SCRIPTS)
-	install -dD $(DESTDIR)$(PREFIX)/lib/systemd/system
-	install -dD $(DESTDIR)$(PREFIX)/lib/systemd/system/{multi-user,sysinit}.target.wants
-	install -m0644 -t $(DESTDIR)$(PREFIX)/lib/systemd/system $(addprefix systemd/,$(UNITS))
-	ln -sf $(addprefix $(PREFIX)/lib/systemd/system/,$(MULTI_USER_WANTS)) \
-		$(DESTDIR)$(PREFIX)/lib/systemd/system/multi-user.target.wants/
 	install -dD $(DESTDIR)/etc
 	install -m0644 -t $(DESTDIR)/etc etc/m1n1.conf
 	install -dD $(DESTDIR)$(PREFIX)/share/asahi-scripts
 	install -m0644 -t $(DESTDIR)$(PREFIX)/share/asahi-scripts functions.sh
 
 install-arch: install
+	install -m0755 -t $(DESTDIR)$(PREFIX)/bin/ $(BUILD_ARCH_SCRIPTS)
+	install -dD $(DESTDIR)$(PREFIX)/lib/systemd/system
+	install -dD $(DESTDIR)$(PREFIX)/lib/systemd/system/{multi-user,sysinit}.target.wants
+	install -m0644 -t $(DESTDIR)$(PREFIX)/lib/systemd/system $(addprefix systemd/,$(UNITS))
+	ln -sf $(addprefix $(PREFIX)/lib/systemd/system/,$(MULTI_USER_WANTS)) \
+		$(DESTDIR)$(PREFIX)/lib/systemd/system/multi-user.target.wants/
 	install -dD $(DESTDIR)$(PREFIX)/lib/initcpio/install
 	install -m0644 -t $(DESTDIR)$(PREFIX)/lib/initcpio/install initcpio/install/asahi
 	install -dD $(DESTDIR)$(PREFIX)/lib/initcpio/hooks


### PR DESCRIPTION
- On Fedora we don't need first-boot and update-grub, so gate them out
- Condizionalize binaries path so we can install them in sbin
- Add a clean target 