### PR TITLE
update-vendor-firmware: various fixes to support firmware installation on boot in Fedora

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SCRIPTS=update-vendor-firmware update-m1n1
 ARCH_SCRIPTS=update-grub first-boot
 UNITS=first-boot.service
 MULTI_USER_WANTS=first-boot.service
+FEDORA_UNITS=update-vendor-firmware.service
 DRACUT_CONF_DIR=$(PREFIX)/lib/dracut/dracut.conf.d
 BUILD_SCRIPTS=$(addprefix build/,$(SCRIPTS))
 BUILD_ARCH_SCRIPTS=$(addprefix build/,$(ARCH_SCRIPTS))
@@ -42,6 +43,8 @@ install-arch: install
 	install -m0644 -t $(DESTDIR)$(PREFIX)/share/libalpm/hooks libalpm/hooks/95-m1n1-install.hook
 
 install-fedora: install
+	install -dD $(DESTDIR)$(PREFIX)/lib/systemd/system
+	install -m0644 -t $(DESTDIR)$(PREFIX)/lib/systemd/system $(addprefix systemd/,$(FEDORA_UNITS))
 	install -dD $(DESTDIR)$(DRACUT_CONF_DIR)
 	install -m0644 -t $(DESTDIR)$(DRACUT_CONF_DIR) dracut/10-asahi.conf
 

--- a/systemd/update-vendor-firmware.service
+++ b/systemd/update-vendor-firmware.service
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT
+
+[Unit]
+Description=Update vendor firmware
+DefaultDependencies=no
+Conflicts=shutdown.target
+After=systemd-remount-fs.target
+Before=systemd-udev-trigger.service sysinit.target shutdown.target
+ConditionDirectoryNotEmpty=/run/vendorfw
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Environment=VENDORFW=/run/vendorfw
+ExecStart=update-vendor-firmware
+ExecStart=rm -r /run/vendorfw
+
+[Install]
+WantedBy=sysinit.target

--- a/update-vendor-firmware
+++ b/update-vendor-firmware
@@ -57,7 +57,7 @@ if [ -e "$TARGET_MANIFEST" ]; then
 fi
 
 echo "Extracting updated vendor firmware..."
-tar xf "$VENDORFW/firmware.tar"
+tar -x --overwrite -f "$VENDORFW/firmware.tar"
 
 if [ -e "$TARGET_MANIFEST" ]; then
     echo "Cleaning up obsolete firmware..."

--- a/update-vendor-firmware
+++ b/update-vendor-firmware
@@ -17,6 +17,7 @@ fi
 : ${TARGET_ROOT:=/}
 : ${TARGET:=/lib/firmware/}
 : ${TARGET_MANIFEST:=".vendorfw.manifest"}
+: ${CACHE:=}
 
 umount=false
 
@@ -54,6 +55,12 @@ if [ -e "$TARGET_MANIFEST" ]; then
         $umount && umount /run/.system-efi
         exit 0
     fi
+fi
+
+if [ -n "$CACHE" ]; then
+  echo "Caching vendor firmware..."
+  cp -pr "$VENDORFW" /run
+  VENDORFW=/run/vendorfw
 fi
 
 echo "Extracting updated vendor firmware..."


### PR DESCRIPTION
While testing https://github.com/AsahiLinux/asahi-scripts/pull/9 I've noticed `tar` fails with a very non obvious "file exists" error if the filesystem is read only. Passing `--overwrite` makes is fail explicitly with a read only fs error, which is much more useful. I've checked and busybox tar supports these options just fine.