### PR TITLE
asahi-fwextract: fix overzealous quoting

### DIFF
--- a/asahi-fwextract
+++ b/asahi-fwextract
@@ -40,7 +40,7 @@ fi
 
 echo "Upgrading vendor firmware package"
 "$PYTHON" -m asahi_firmware.update "$ASAHIFW" "$VENDORFWTMP"
-mv -f "${VENDORFWTMP}/*" "$VENDORFW"
+mv -f ${VENDORFWTMP}/* "$VENDORFW"
 rmdir "$VENDORFWTMP"
 echo "Firmware upgraded"
 


### PR DESCRIPTION
Can't quote here as it impedes globbing, causing the move to fail.