### PR TITLE
resolved issue with dracut module

### DIFF
--- a/dracut/modules.d/99asahi-firmware/load-asahi-firmware.sh
+++ b/dracut/modules.d/99asahi-firmware/load-asahi-firmware.sh
@@ -3,11 +3,6 @@
 
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
-if [ -e /vendorfw ]; then
-    info ":: Asahi: Vendor firmware was loaded by the bootloader"
-    return 0
-fi
-
 if [ ! -e /proc/device-tree/chosen/asahi,efi-system-partition ]; then
     info ":: Asahi: Missing asahi,efi-system-partition variable, firmware will not be loaded!"
     return 0

--- a/dracut/modules.d/99asahi-firmware/module-setup.sh
+++ b/dracut/modules.d/99asahi-firmware/module-setup.sh
@@ -25,7 +25,7 @@ installkernel() {
 
 # called by dracut
 install() {
-    inst_dir "/lib/firmware"
+    inst_dir "/lib/firmware/vendor"
     ln_r "/lib/firmware/vendor" "/vendorfw"
     asahiscriptsdir="/usr/share/asahi-scripts"
     inst_dir $asahiscriptsdir


### PR DESCRIPTION
ref issue: https://github.com/AsahiLinux/asahi-scripts/issues/15

`inst_dir` needs to create `/lib/firmware/vendor`

```diff
 install() {
-    inst_dir "/lib/firmware"
+    inst_dir "/lib/firmware/vendor"
     ln_r "/lib/firmware/vendor" "/vendorfw"

```
Otherwise `ln_r "/lib/firmware/vendor" "/vendorfw"` will point to a non-existent directory  
....and `firmware.cpio` can't be extracted to a non-existent directory. 

Also, I fail to see how
```bash
 [ -e /vendorfw ]; then
    info ":: Asahi: Vendor firmware was loaded by the bootloader"
    return 0
fi
```

...is somehow validating that the firmware has been loaded.   
That's just a symlink to `/lib/firmware/vendor`   
But maybe I'm missing something?? 

How are we meant to verify that the firmware has been loaded?  
Or should we just be extracting `firmware.cpio` on every boot?