### PR TITLE
 update-m1n1: allow default script to take over building m1n1 binary

### DIFF
--- a/update-m1n1
+++ b/update-m1n1
@@ -5,6 +5,8 @@ set -e
 
 [ -e /etc/default/update-m1n1 ] && . /etc/default/update-m1n1
 
+[ $M1N1_MANAGED_MANUALLY == 1 ] && exit 0
+
 if [ -e "$(dirname "$0")"/functions.sh ]; then
     . "$(dirname "$0")"/functions.sh
 else


### PR DESCRIPTION
Had to close and open new for this one because it was easier to sync.

Reposting:

Mini addition but also discussion.

Let's allow users to have their own script to manage m1n1 since not everyone might be using UBoot GRUB etc.

Personally I directly boot my kernel from m1n1 stage 2 and have mini scripts that also (minimally) manage binary files such that I always have at least a snapshot of:

    1. The last successful direct m1n1 stage 2 boot.
    2. The last successful UBoot GRUB boot. (for USB fixing etc.)

