### PR TITLE
first-boot: use mlabel to randomize efi

### DIFF
--- a/first-boot
+++ b/first-boot
@@ -19,10 +19,9 @@ if [ -e "$efi_dev" ] && \
     blkid "$efi_dev" | grep -q 'TYPE="vfat"'; then
 
     echo "Randomizing EFI system partition UUID..."
-    # Ugly... why isn't there a command to do this?
-    ssize="$(blockdev --getss "$efi_dev")"
-    dd bs=1 seek=67 count=4 conv=notrunc if=/dev/urandom of="$efi_dev"
-    dd bs=1 skip=67 seek=$((67+6*$ssize)) count=4 conv=notrunc if="$efi_dev" of="$efi_dev"
+
+    # mlabel -n -i "$efi_dev" ::
+    fatlabel -i -r "$efi_dev"
 
     efi_uuid="$(blkid -c /dev/null "$efi_dev" -o export | grep '^UUID=')"
     echo "EFI partition: $efi_uuid"


### PR DESCRIPTION
Does this make sense?