### PR TITLE
fix: explicit use bash for update-grub

### DIFF
--- a/update-grub
+++ b/update-grub
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # SPDX-License-Identifier: MIT
 
 set -e

--- a/update-m1n1
+++ b/update-m1n1
@@ -5,6 +5,8 @@ set -e
 
 [ -e /etc/default/update-m1n1 ] && . /etc/default/update-m1n1
 
+[ $M1N1_MANAGED_MANUALLY == 1 ] && exit 0
+
 if [ -e "$(dirname "$0")"/functions.sh ]; then
     . "$(dirname "$0")"/functions.sh
 else

--- a/update-m1n1
+++ b/update-m1n1
@@ -5,7 +5,7 @@ set -e
 
 [ -e /etc/default/update-m1n1 ] && . /etc/default/update-m1n1
 
-[ $M1N1_MANAGED_MANUALLY == 1 ] && exit 0
+[ -n $M1N1_UPDATE_DISABLED ] && exit 0
 
 if [ -e "$(dirname "$0")"/functions.sh ]; then
     . "$(dirname "$0")"/functions.sh


### PR DESCRIPTION
I use dash as /bin/sh on my system.

Actual script is not posix compliant some piece of code are bash only, I propose to just force /bin/bash here.

Or we should convert them all to posix, in case some people, use dash for example.