### PR TITLE
umount esp upon completion

### DIFF
--- a/dracut/modules.d/99asahi-firmware/load-asahi-firmware.sh
+++ b/dracut/modules.d/99asahi-firmware/load-asahi-firmware.sh
@@ -45,3 +45,4 @@ fi
 
 ( cd /; cpio --quiet -i < "$VENDORFW/firmware.cpio" )
 info ":: Asahi firmware unpacked successfully"
+umount /run/.system-efi


### PR DESCRIPTION
Not sure there's if there's a good reason to leave the esp persistently mounted here for the duration of the boot session. 
Other commands/functions that mount the esp such update-m1n1 will unmount the esp once they've completed.  