### PR TITLE
Use grub-editenv to create grub environment file.

### DIFF
--- a/update-grub
+++ b/update-grub
@@ -50,7 +50,7 @@ EOF
 echo "Installing GRUB files..."
 mkdir -p "$GRUB_DIR"
 touch "$GRUB_DIR"/device.map
-dd if=/dev/zero of="$GRUB_DIR"/grubenv bs=1024 count=1 2>/dev/null
+grub-editenv "$GRUB_DIR"/grubenv create
 cp -r /usr/share/grub/themes "$GRUB_DIR"
 cp -r /usr/lib/grub/arm64-efi "$GRUB_DIR"
 rm -f "$GRUB_DIR"/arm64-efi/*.module


### PR DESCRIPTION
It looks like this is the official way to create a new environment file. Interestingly that will initialize the buffer to all `0x23`. Filling it with `0x00` gives me `error: invalid environment file` at boot on Ubuntu.

The Arch wiki mentions `grub-editenv` create at https://wiki.archlinux.org/title/GRUB so I suppose it is also a good idea to use it there.