### PR TITLE
Mount vendorfw tmpfs with stricter permissions

### DIFF
--- a/dracut/modules.d/99asahi-firmware/install-asahi-firmware.sh
+++ b/dracut/modules.d/99asahi-firmware/install-asahi-firmware.sh
@@ -8,5 +8,5 @@ if [ ! -d /sysroot/lib/firmware/vendor ]; then
     warn ":: Asahi: Vendor firmware directory missing on the root filesystem!"
     return 1
 fi
-mount -t tmpfs vendorfw /sysroot/lib/firmware/vendor
+mount -t tmpfs -o mode=0755 vendorfw /sysroot/lib/firmware/vendor
 cp -pr /vendorfw/* /vendorfw/.vendorfw.manifest /sysroot/lib/firmware/vendor

--- a/dracut/modules.d/99asahi-firmware/load-asahi-firmware.sh
+++ b/dracut/modules.d/99asahi-firmware/load-asahi-firmware.sh
@@ -45,3 +45,4 @@ fi
 
 ( cd /; cpio --quiet -i < "$VENDORFW/firmware.cpio" )
 info ":: Asahi firmware unpacked successfully"
+umount /run/.system-efi

--- a/initcpio/hooks/asahi
+++ b/initcpio/hooks/asahi
@@ -53,6 +53,6 @@ run_latehook() {
     [ -e /vendorfw ] || return
     msg ":: Asahi: Copying vendor firmware to tmpfs under root filesystem..."
     mkdir -p /new_root/lib/firmware/vendor
-    mount -t tmpfs vendorfw /new_root/lib/firmware/vendor
+    mount -t tmpfs -o mode=0755 vendorfw /new_root/lib/firmware/vendor
     cp -r /vendorfw/* /vendorfw/.vendorfw.manifest /new_root/lib/firmware/vendor
 }

--- a/update-m1n1
+++ b/update-m1n1
@@ -5,6 +5,8 @@ set -e
 
 [ -e /etc/default/update-m1n1 ] && . /etc/default/update-m1n1
 
+[ $M1N1_MANAGED_MANUALLY == 1 ] && exit 0
+
 if [ -e "$(dirname "$0")"/functions.sh ]; then
     . "$(dirname "$0")"/functions.sh
 else

--- a/update-m1n1
+++ b/update-m1n1
@@ -5,7 +5,7 @@ set -e
 
 [ -e /etc/default/update-m1n1 ] && . /etc/default/update-m1n1
 
-[ $M1N1_MANAGED_MANUALLY == 1 ] && exit 0
+[ -n $M1N1_UPDATE_DISABLED ] && exit 0
 
 if [ -e "$(dirname "$0")"/functions.sh ]; then
     . "$(dirname "$0")"/functions.sh


### PR DESCRIPTION
By default tmpfs uses 1777 which is more permissive than necessary. Use 0755 like the rest of /lib/firmware instead.