### PR TITLE
Add initramfs-tools implementation for cpio firmware loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,18 @@ install-arch: install install-mkinitcpio
 	install -dD $(DESTDIR)$(PREFIX)/share/libalpm/hooks
 	install -m0644 -t $(DESTDIR)$(PREFIX)/share/libalpm/hooks libalpm/hooks/95-m1n1-install.hook
 
+install-initramfs: install
+	install -d $(DESTDIR)/etc/initramfs-tools/hooks/
+	install -m0755 -t $(DESTDIR)/etc/initramfs-tools/hooks/ initramfs/hooks/asahi
+	install -d $(DESTDIR)/etc/initramfs-tools/scripts/init-top
+	install -m0755 -t $(DESTDIR)/etc/initramfs-tools/scripts/init-top initramfs/scripts/init-top/asahi
+	install -d $(DESTDIR)/etc/initramfs-tools/scripts/init-bottom
+	install -m0755 -t $(DESTDIR)/etc/initramfs-tools/scripts/init-bottom initramfs/scripts/init-bottom/asahi
+	install -m0644 -t $(DESTDIR)$(PREFIX)/share/asahi-scripts initramfs/modules
+
 install-fedora: install install-dracut
+
+install-ubuntu: install install-initramfs
 
 uninstall:
 	rm -f $(addprefix $(DESTDIR)$(BIN_DIR)/,$(SCRIPTS))
@@ -67,6 +78,11 @@ uninstall-mkinitcpio:
 uninstall-dracut:
 	rm -f $(DESTDIR)$(DRACUT_CONF_DIR)/10-asahi.conf
 
+uninstall-initramfs:
+	rm -f $(DESTDIR)/etc/initramfs-tools/hooks/asahi
+	rm -f $(DESTDIR)/etc/initramfs-tools/scripts/init-top/asahi
+	rm -f $(DESTDIR)/etc/initramfs-tools/scripts/init-bottom/asahi
+
 uninstall-arch: uninstall-mkinitcpio
 	rm -f $(addprefix $(DESTDIR)$(BIN_DIR)/,$(ARCH_SCRIPTS))
 	rm -f $(addprefix $(DESTDIR)$(PREFIX)/lib/systemd/system/,$(UNITS))
@@ -74,5 +90,7 @@ uninstall-arch: uninstall-mkinitcpio
 	rm -f $(DESTDIR)$(PREFIX)/share/libalpm/hooks/95-m1n1-install.hook
 
 uninstall-fedora: uninstall-dracut
+
+uninstall-ubuntu: uninstall-initramfs
 
 .PHONY: clean install install-mkinitcpio install-dracut install-arch install-fedora uninstall uninstall-mkinitcpio uninstall-dracut uninstall-arch uninstall-fedora

--- a/functions.sh
+++ b/functions.sh
@@ -43,7 +43,7 @@ mount_sys_esp() {
         mount --bind "$bootmnt" "$mountpoint"
         warn "System ESP not identified in device tree, using $bootmnt"
     else
-        mount "PARTUUID=$esp_uuid" "$mountpoint"
+        mount "/dev/disk/by-partuuid/$esp_uuid" "$mountpoint"
     fi
     dev="$(grep "$mountpoint" /proc/mounts | cut -d" " -f1)"
     info "Mounted System ESP $dev at $mountpoint"
@@ -72,7 +72,7 @@ mount_boot_esp() {
             return 1
         fi
 
-        mount "PARTUUID=$esp_uuid" "$mountpoint"
+        mount "/dev/disk/by-partuuid/$esp_uuid" "$mountpoint"
     fi
     info "Mounted Boot ESP at $mountpoint"
 }

--- a/initramfs/hooks/asahi
+++ b/initramfs/hooks/asahi
@@ -1,0 +1,27 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+PREREQ=""
+
+prereqs()
+{
+        echo "$PREREQ"
+}
+
+case $1 in
+prereqs)
+        prereqs
+        exit 0
+        ;;
+esac
+
+# Hooks for loading asahi modules and firmware
+
+. /usr/share/initramfs-tools/hook-functions
+
+mkdir -p "${DESTDIR}/lib/firmware"
+mkdir -p "${DESTDIR}/usr/share/asahi-scripts"
+cp -r /usr/share/asahi-scripts/* "${DESTDIR}/usr/share/asahi-scripts"
+copy_exec /usr/bin/cpio
+
+add_modules_from_file /usr/share/asahi-scripts/modules

--- a/initramfs/modules
+++ b/initramfs/modules
@@ -1,0 +1,33 @@
+# For NVMe & SMC
+apple-mailbox
+# For NVMe
+nvme_apple
+# For USB and HID
+pinctrl-apple-gpio
+# SMC core
+macsmc
+macsmc-rtkit
+# For USB
+i2c-apple
+tps6598x
+apple-dart
+dwc3
+dwc3-of-simple
+nvmem-apple-efuses
+phy-apple-atc
+xhci-pci
+pcie-apple
+gpio_macsmc
+# For HID
+spi-apple
+spi-hid-apple
+spi-hid-apple-of
+# For RTC
+rtc-macsmc
+simple-mfd-spmi
+spmi-apple-controller
+nvmem_spmi_mfd
+# For MTP HID
+apple-dockchannel
+dockchannel-hid
+apple-rtkit-helper

--- a/initramfs/scripts/init-bottom/asahi
+++ b/initramfs/scripts/init-bottom/asahi
@@ -1,0 +1,20 @@
+#!/usr/bin/sh
+# SPDX-License-Identifier: MIT
+
+PREREQ=""
+prereqs()
+{
+        echo "$PREREQ"
+}
+case $1 in
+# get pre-requisites
+prereqs)
+        prereqs
+        exit 0
+        ;;
+esac
+
+. /scripts/functions
+
+mount -t tmpfs -o mode=0755 vendorfw "${rootmnt}"/lib/firmware/vendor
+cp -r /vendorfw/* /vendorfw/.vendorfw.manifest "${rootmnt}"/lib/firmware/vendor

--- a/initramfs/scripts/init-top/asahi
+++ b/initramfs/scripts/init-top/asahi
@@ -1,0 +1,62 @@
+#!/usr/bin/sh
+# SPDX-License-Identifier: MIT
+
+PREREQ="udev"
+prereqs()
+{
+        echo "$PREREQ"
+}
+case $1 in
+# get pre-requisites
+prereqs)
+        prereqs
+        exit 0
+        ;;
+esac
+
+. /scripts/functions
+
+if [ -e /lib/firmware/vendor ]; then
+	log_failure_msg "Vendor firmware was loaded by the bootloader"
+	return 1
+fi
+
+if [ ! -e /proc/device-tree/chosen/asahi,efi-system-partition ]; then
+	log_failure_msg "Missing asahi,efi-system-partition variable, firmware will not be loaded!"
+	return 1
+fi
+
+log_success_msg "Load NVME modules"
+modprobe apple-mailbox
+modprobe nvme-apple
+
+for i in $(seq 0 50); do
+[ -e /sys/bus/platform/drivers/nvme-apple/*.nvme/nvme/nvme*/nvme*n1/ ] && break
+	sleep 0.1
+done
+
+if [ ! -e /sys/bus/platform/drivers/nvme-apple/*.nvme/nvme/nvme*/nvme*n1/ ]; then
+err "Timed out waiting for NVMe device"
+	return 1
+fi
+
+# If the above exists, hopefully the /dev device exists and this will work
+
+VENDORFW="/run/.system-efi/vendorfw/"
+
+(
+	. /usr/share/asahi-scripts/functions.sh
+	mount_sys_esp /run/.system-efi
+)
+
+if [ ! -e "$VENDORFW/firmware.cpio" ]; then
+	log_failure_msg "Vendor firmware not available in ESP!"
+	umount /run/.system-efi
+	return 1
+fi
+
+
+( cd /; cpio -i < "$VENDORFW/firmware.cpio" )
+umount /run/.system-efi
+
+log_success_msg "Asahi: Vendor firmware unpacked successfully"


### PR DESCRIPTION
This PR adds our Ubuntu implementation for firmware loading with initramfs-tools. I am sharing this here because I think it might also be useful for other initramfs-tools based distros such as Debian or Pop!_Os.

The changes added are:

- Add initramfs hooks and boot scripts to extract and mount firmware
- Add initramfs and ubuntu make targets
- busybox mount doesn't support PARTUUID= so use /dev/disk/by-partuuid

The initramfs scripts are pretty much identical to the dracut and initcpio versions.
The only change I had to make to the existing code is because of a limitation in busybox which we use in our initrd.
busybox mount does not support `PARTUUID` so I am using `/dev/disk/by-partuuid` instead. As I understand it that approach should be fairly portable but I wouldn't mind making it a Ubuntu-only quirk either.