### PR TITLE
dracut: Add asahi-dev-modules dracut module

### DIFF
--- a/dracut/modules.d/99asahi-dev-modules/install-asahi-dev-modules.sh
+++ b/dracut/modules.d/99asahi-dev-modules/install-asahi-dev-modules.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if [ ! -d /$(uname -r) ]; then
+    return 0
+fi
+
+DESTDIR="/sysroot/lib/modules/$(uname -r)"
+
+info ":: Asahi: Installing dev kernel modules to root filesystem..."
+if [ ! -e ${DESTDIR} ]; then
+    if [ ! -w /sysroot ]; then
+        error ":: Asahi: root fs not writable!"
+        return 0
+    fi
+
+    mkdir -p ${DESTDIR}
+fi
+
+mount -t tmpfs -o mode=0755,size=192m dev-modules /${DESTDIR}
+cp -pr /$(uname -r)/* ${DESTDIR}/

--- a/dracut/modules.d/99asahi-dev-modules/link-asahi-dev-modules.sh
+++ b/dracut/modules.d/99asahi-dev-modules/link-asahi-dev-modules.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if [ -d /$(uname -r) ]; then
+    info ":: Asahi: dev modules present, link them into system"
+    ln -s /$(uname -r) /lib/modules/
+fi

--- a/dracut/modules.d/99asahi-dev-modules/module-setup.sh
+++ b/dracut/modules.d/99asahi-dev-modules/module-setup.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+# called by dracut
+check() {
+    if [ -n "$hostonly" ] && [ ! -e /proc/device-tree/chosen/asahi,efi-system-partition ]; then
+       return 0
+    elif [ -z "$hostonly" ]; then
+        return 0
+    else
+       return 255
+    fi
+}
+
+# called by dracut
+depends() {
+    echo fs-lib
+    return 0
+}
+
+# called by dracut
+install() {
+    inst_multiple cp ln mkdir mount
+    inst_hook pre-udev 99 "${moddir}/link-asahi-dev-modules.sh"
+    inst_hook pre-pivot 99 "${moddir}/install-asahi-dev-modules.sh"
+}


### PR DESCRIPTION
This module makes modules of a development kernel blended into the initrd at "/$(uname -r) available in the initrd and root fs.

This depends on a writable root fs mount or an existing /sysroot/lib/modules/$(uname -r) directory. The script mounts a tmpfs and copies the modules into it.

The cpio archive can be created during the kernel build with
```
make dir-pkg && \
usr/gen_initramfs.sh -o initramfs_modules.cpio -u squash -g squash tar-install/lib/modules && \
gzip -f --fast initramfs_modules.cpio
```

usr/gen_initramfs.sh does not work with out of tree build. A simple workaround is to copy usr/gen_initramfs from kernel build dir to usr/ in the kernel source dir.

The regular initramfs, a firmware.cpio.gz and initramfs_modules.cpio.gz can then be concatenated and used as initramfs for run_guest_kernel.sh.

This allows using a distro kernel config with a local build and tethered booting for fast cycles.

These module is not enabled by default but requires a dracut config fragment with:
```
add_dracutmodules+=" asahi-dev-modules "
```

Example use with run_guest_kernel.sh:
```
cat ~/asahi/fedora/initramfs-6.5.4-403.asahi.fc39.aarch64+16k.img \
    ~/asahi/fw/firmware_13.5_j314.cpio.gz \
    ~/src/linux/initramfs.cpio.gz > /tmp/initramfs.gz && \
tools/run_guest_kernel.sh ~/src/linux/${KERNEL_BUILD} \
    "root=/dev/nvme0n1p14 rootflags=subvol=root,rw hostname=mbp14f" /tmp/initramfs.gz
```