### PR TITLE
dracut: Add vfat as explicit dependency for asahi-firmware

### DIFF
--- a/dracut/modules.d/99asahi-firmware/module-setup.sh
+++ b/dracut/modules.d/99asahi-firmware/module-setup.sh
@@ -20,7 +20,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods apple-mailbox nvme-apple
+    instmods apple-mailbox nvme-apple vfat
 }
 
 # called by dracut


### PR DESCRIPTION
Required when the ESP is not mounted for example due to booting an USB image to encrypt the rootfs. `dracut --force` will in that situation not include vfat in the initramfs resulting in missing firmware when using that initramfs.