### PR TITLE
functions.sh: be more precise while reading /proc/mount

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -24,7 +24,7 @@ mount_sys_esp() {
     mountpoint="$1"
 
     mkdir -p "$mountpoint"
-    while grep -q "$mountpoint" /proc/mounts; do
+    while grep -q " $mountpoint " /proc/mounts; do
         umount "$mountpoint"
     done
 
@@ -54,7 +54,7 @@ mount_boot_esp() {
     mountpoint="$1"
 
     mkdir -p "$mountpoint"
-    while grep -q "$mountpoint" /proc/mounts; do
+    while grep -q " $mountpoint " /proc/mounts; do
         umount "$mountpoint"
     done
 


### PR DESCRIPTION
The /proc/mount file is a space-separated table of all devices mounted. The current implementation only greps for a matching pattern without taking this into account. This may cause a misreading of /proc/mount when, say, the ESP was mounted at /efi (AOSC OS default).

For instance:

```
$ grep /efi /proc/mounts 
efivarfs /sys/firmware/efi/efivars efivarfs rw,nosuid,nodev,noexec,relatime 0 0
systemd-1 /efi autofs rw,relatime,fd=50,pgrp=1,timeout=120,minproto=5,maxproto=5,direct,pipe_ino=21868 0 0
```

Also match the spaces on either end of the mount path to avoid this issue.