### PR TITLE
asahi-diagnose: add checks for speaker early adopters

### DIFF
--- a/asahi-diagnose
+++ b/asahi-diagnose
@@ -67,6 +67,63 @@ system_info() {
 EOF
 }
 
+
+
+# Check for the Pro Audio profile (installed before early 2023)
+check_proaudio() {
+    grep "alsa_output.platform-sound.pro-output.." "${HOME}/.local/state/wireplumber/restore-stream" > /dev/null \
+    && echo "yes" \
+    || echo "no"
+}
+pro_audio=$(check_proaudio)
+
+# Check for Configs in /etc/ (installed before mid 2023)
+check_audio_oldconfs() {
+    [ -e /etc/pipewire/pipewire.conf.d/*asahi* ] \
+    || [ -e /etc/wireplumber/policy.lua.d/99-asahi-policy.lua ] \
+    && echo "yes" \
+    || echo "no"
+}
+old_conf=$(check_audio_oldconfs)
+
+# Check for the racy 99-asahi* build (installed before ~Oct 2023)
+check_audio_oldbuild() {
+    [ -e /usr/share/wireplumber/policy.lua.d/99-asahi-policy.lua ] \
+    && echo "yes" \
+    || echo "no"
+}
+racy_build=$(check_audio_oldbuild)
+
+# Check if snd-soc-macaudio.please_blow_up_my_speakers was requested
+check_audio_macaudio() {
+    grep "0" /sys/module/snd_soc_macaudio/parameters/please_blow_up_my_speakers > /dev/null \
+    && echo "no" \
+    || echo "yes"
+}
+bad_macaudio_params=$(check_audio_macaudio)
+
+# Check that snd-soc-tas2764.apple_quirks=0x3f is being applied
+check_audio_tas2764() {
+    [ -e /sys/module/snd_soc_tas2764/ ] && (
+        grep "63" /sys/module/snd_soc_tas2764/parameters/apple_quirks > /dev/null \
+        && echo "yes" \
+        || echo "no"
+    ) || echo "N/A"
+}
+tas2764_quirks=$(check_audio_tas2764)
+
+audio_config() {
+    cat <<EOF
+## Audio Configuration:
+    Pro Audio profile detected: $pro_audio
+    Old configuration files in \`/etc/\`: $old_conf
+    File conflicts in \`/usr/share/\`: $racy_build
+    Speaker detonation requested: $bad_macaudio_params
+    TAS2764 quirks applied: $tas2764_quirks
+
+EOF
+}
+
 getfile() {
     cat <<EOF
 ## $2
@@ -152,6 +209,7 @@ diagnose() {
         firmware_versions
         boot_config
         system_info
+        audio_config
         environment
         getfile /proc/mounts "Mounts"
         [ -e /etc/arch-release ] && package_versions
@@ -167,6 +225,29 @@ diagnose() {
     )
 
     log "Saved diagnostic information to $f"
+
+    if [ "$pro_audio" == "yes" ] || \
+       [ "$old_conf" == "yes" ] || \
+       [ "$racy_build" == "yes" ] \
+       [ "$bad_macaudio_params" == "yes" ] || \
+       [ "$tas2764_quirks" == "no" ]; then
+        echo
+        echo "!! IMPORTANT !!"
+        echo "Your audio configuration is in an invalid state. It is likely that you tried to"
+        echo "enable speakers early, despite numerous and very explicit warnings not to do so."
+        echo "Potential reason(s) you are seeing this message: "
+        (
+            [ "$pro_audio" == "yes" ] && echo "    - The Pro Audio profile is/was enabled for the internal speakers."
+            [ "$old_conf" == "yes" ] && echo "    - You have files in /etc/ from a prerelease version of asahi-audio."
+            [ "$racy_build" == "yes" ] && echo "    - You have files in /usr/share/ from a prerelease version of asahi-audio."
+            [ "$bad_macaudio_params" == "yes" ] && echo "    - You have tried to manually circumvent our kernel-level safety controls."
+            [ "$tas2764_quirks" == "no" ] && echo "    - Required speaker codec settings are not being applied."
+        )
+        echo "Please go to https://github.com/AsahiLinux/docs/wiki/Undoing-early-speaker-support-hacks for fixes."
+        echo "Do NOT file audio-related bugs until you have tried ALL fixes suggested at the page above."
+        echo "Your bugs will be ignored and you will not be assisted."
+    fi
+
 
     plat="$(cat /proc/device-tree/compatible | sed -re 's/.*apple,(t....).*/\1/g')"
     ver="$(tr -d '\0' </proc/device-tree/chosen/asahi,os-fw-version)"


### PR DESCRIPTION
users were explicitly warned not to enable speakers early. these warnings were often. check for telltale signs that they hacked their way to enabled speakers despite this, and impolitely warn them that they will not receive support until they undo any early adopter hacks detected by this script.