### PR TITLE
dracut: conf: Fix i2c module name

### DIFF
--- a/dracut/dracut.conf.d/10-asahi.conf
+++ b/dracut/dracut.conf.d/10-asahi.conf
@@ -13,7 +13,7 @@ add_drivers+=" pinctrl-apple-gpio "
 add_drivers+=" macsmc macsmc-rtkit "
 
 # For USB
-add_drivers+=" i2c-apple tps6598x apple-dart dwc3 dwc3-of-simple nvmem-apple-efuses phy-apple-atc xhci-plat-hcd xhci-pci pcie-apple gpio_macsmc "
+add_drivers+=" i2c-pasemi-platform tps6598x apple-dart dwc3 dwc3-of-simple nvmem-apple-efuses phy-apple-atc xhci-plat-hcd xhci-pci pcie-apple gpio_macsmc "
 
 # For HID
 add_drivers+=" spi-apple spi-hid-apple spi-hid-apple-of "


### PR DESCRIPTION
Fixes USB support in the initramfs by reverting the unintentional omission of apple-dart.ko, apple-rtkit-helper.ko,
spmi-apple-controller.ko and dwc3-of-simple.ko from the initramfs. Due to the missing dart module lot's of other HW was unusable in the initramfs as well.
Does not fix the late probing of the rtc-macsmc modfule.

The upstream module name for the i2c blocks is i2c-pasemi-platform. Although dracut includes the module already it on its own it still causes problems. Dracut seems to ignore all other modules when it can't find one of the entries in the 'add_drivers' variable.