### PR TITLE
dracut: fix kernel module handling

### DIFF
--- a/dracut/dracut.conf.d/10-asahi.conf
+++ b/dracut/dracut.conf.d/10-asahi.conf
@@ -1,28 +1,28 @@
 # Modules necessary for using Linux on Apple Silicon Macs
 
 # For NVMe & SMC
-add_drivers+=" apple-mailbox "
+drivers+=" apple-mailbox "
 
 # For NVMe
-add_drivers+=" nvme_apple "
+drivers+=" nvme_apple "
 
 # For USB and HID
-add_drivers+=" pinctrl-apple-gpio "
+drivers+=" pinctrl-apple-gpio "
 
 # SMC core
-add_drivers+=" macsmc macsmc-rtkit "
+drivers+=" macsmc macsmc-rtkit "
 
 # For USB
-add_drivers+=" i2c-pasemi-platform tps6598x apple-dart dwc3 dwc3-of-simple nvmem-apple-efuses phy-apple-atc xhci-plat-hcd xhci-pci pcie-apple gpio_macsmc "
+drivers+=" i2c-pasemi-platform tps6598x apple-dart dwc3 dwc3-of-simple nvmem-apple-efuses phy-apple-atc xhci-plat-hcd xhci-pci pcie-apple gpio_macsmc "
 
 # For HID
-add_drivers+=" spi-apple spi-hid-apple spi-hid-apple-of "
+drivers+=" spi-apple spi-hid-apple spi-hid-apple-of "
 
 # For RTC
-add_drivers+=" rtc-macsmc simple-mfd-spmi spmi-apple-controller nvmem_spmi_mfd "
+drivers+=" rtc-macsmc simple-mfd-spmi spmi-apple-controller nvmem_spmi_mfd "
 
 # For MTP HID
-add_drivers+=" apple-dockchannel dockchannel-hid apple-rtkit-helper "
+drivers+=" apple-dockchannel dockchannel-hid apple-rtkit-helper "
 
 # dwc3 instantiates xHCI asynchronously. To make things like init=/bin/sh work where udev is no longer running, force load this one.
 force_drivers+=" xhci-plat-hcd "

--- a/dracut/dracut.conf.d/10-asahi.conf
+++ b/dracut/dracut.conf.d/10-asahi.conf
@@ -25,6 +25,9 @@ drivers+=" rtc-macsmc simple-mfd-spmi spmi-apple-controller nvmem_spmi_mfd "
 # For MTP HID
 drivers+=" apple-dockchannel dockchannel-hid apple-rtkit-helper "
 
+# For display (DPTX and DP audio)
+drivers+=" mux-apple-display-crossbar phy-apple-dptx apple-sio "
+
 # dwc3 instantiates xHCI asynchronously. To make things like init=/bin/sh work where udev is no longer running, force load this one.
 force_drivers+=" xhci-plat-hcd "
 

--- a/dracut/dracut.conf.d/10-asahi.conf
+++ b/dracut/dracut.conf.d/10-asahi.conf
@@ -13,7 +13,8 @@ drivers+=" pinctrl-apple-gpio "
 drivers+=" macsmc macsmc-rtkit "
 
 # For USB
-drivers+=" i2c-pasemi-platform tps6598x apple-dart dwc3 dwc3-of-simple nvmem-apple-efuses phy-apple-atc xhci-plat-hcd xhci-pci pcie-apple gpio_macsmc "
+# add both i2c-apple and i2c-pasemi-platform since Linux 6.8 renamed the module
+drivers+=" i2c-apple i2c-pasemi-platform tps6598x apple-dart dwc3 dwc3-of-simple nvmem-apple-efuses phy-apple-atc xhci-plat-hcd xhci-pci pcie-apple gpio_macsmc "
 
 # For HID
 drivers+=" spi-apple spi-hid-apple spi-hid-apple-of "


### PR DESCRIPTION
Despite the confusing help text for `--drivers` we want to use that since it doesn't half-fail if modules are missing. Modules can be missing due to the `i2c-apple` -> `i2c-pasemi-platform` rename in Linux 6.8 or simple because the drivers are built-in.
`add_drivers` fails in an unfortunate way if modules are missing, it stops processing kernel modules but continues to create the initramfs.