### PR TITLE
dracut: Add module for asahio specific kernel modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ install-mkinitcpio: install
 install-dracut: install
 	install -dD $(DESTDIR)$(DRACUT_CONF_DIR)
 	install -m0644 -t $(DESTDIR)$(DRACUT_CONF_DIR) dracut/dracut.conf.d/10-asahi.conf
+	install -dD $(DESTDIR)$(DRACUT_MODULES_DIR)/91kernel-modules-asahi
+	install -m0755 -t $(DESTDIR)$(DRACUT_MODULES_DIR)/91kernel-modules-asahi dracut/modules.d/91kernel-modules-asahi/module-setup.sh
 	install -dD $(DESTDIR)$(DRACUT_MODULES_DIR)/99asahi-firmware
 	install -m0755 -t $(DESTDIR)$(DRACUT_MODULES_DIR)/99asahi-firmware dracut/modules.d/99asahi-firmware/install-asahi-firmware.sh
 	install -m0755 -t $(DESTDIR)$(DRACUT_MODULES_DIR)/99asahi-firmware dracut/modules.d/99asahi-firmware/load-asahi-firmware.sh

--- a/dracut/dracut.conf.d/10-asahi.conf
+++ b/dracut/dracut.conf.d/10-asahi.conf
@@ -1,31 +1,9 @@
 # Modules necessary for using Linux on Apple Silicon Macs
-
-# For NVMe & SMC
-add_drivers+=" apple-mailbox "
-
-# For NVMe
-add_drivers+=" nvme_apple "
-
-# For USB and HID
-add_drivers+=" pinctrl-apple-gpio "
-
-# SMC core
-add_drivers+=" macsmc macsmc-rtkit "
-
-# For USB
-add_drivers+=" i2c-pasemi-platform tps6598x apple-dart dwc3 dwc3-of-simple nvmem-apple-efuses phy-apple-atc xhci-plat-hcd xhci-pci pcie-apple gpio_macsmc "
-
-# For HID
-add_drivers+=" spi-apple spi-hid-apple spi-hid-apple-of "
-
-# For RTC
-add_drivers+=" rtc-macsmc simple-mfd-spmi spmi-apple-controller nvmem_spmi_mfd "
-
-# For MTP HID
-add_drivers+=" apple-dockchannel dockchannel-hid apple-rtkit-helper "
+# are handled in the module kernel-modules-asahi since add_drivers can't
+# handle missing modules
 
 # dwc3 instantiates xHCI asynchronously. To make things like init=/bin/sh work where udev is no longer running, force load this one.
 force_drivers+=" xhci-plat-hcd "
 
 # For Apple firmware
-add_dracutmodules+=" asahi-firmware "
+add_dracutmodules+=" asahi-firmware kernel-modules-asahi "

--- a/dracut/modules.d/91kernel-modules-asahi/module-setup.sh
+++ b/dracut/modules.d/91kernel-modules-asahi/module-setup.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# called by dracut
+installkernel() {
+    # For NVMe & SMC
+    hostonly='' instmods apple-mailbox
+
+    # For NVMe
+    hostonly='' instmods nvme_apple
+
+    # For USB and HID
+    hostonly='' instmods pinctrl-apple-gpio
+
+    # SMC core
+    hostonly='' instmods macsmc macsmc-rtkit
+
+    # For USB
+    hostonly='' instmods \
+        i2c-apple \
+        i2c-pasemi-platform \
+        tps6598x \
+        apple-dart \
+        dwc3 \
+        dwc3-of-simple \
+        nvmem-apple-efuses \
+        phy-apple-atc \
+        xhci-plat-hcd \
+        xhci-pci \
+        pcie-apple \
+        gpio_macsmc
+
+    # For RTC
+    hostonly='' instmods rtc-macsmc simple-mfd-spmi spmi-apple-controller nvmem_spmi_mfd
+
+    # For HID
+    hostonly='' instmods spi-apple spi-hid-apple spi-hid-apple-of
+
+    # For MTP HID
+    hostonly='' instmods apple-dockchannel dockchannel-hid apple-rtkit-helper
+
+    # For DP / HDMI audio
+    hostonly='' instmods apple-sio
+
+    # For DPTX and HDMI displays
+    hostonly='' instmods mux-apple-display-crossbar phy-apple-dptx
+}


### PR DESCRIPTION
The config based kernel module handling unfortunately fails with missing drivers as the handling of `add_drivers` gives up on the first missing kernel module, prints an error message but carries on to create a initramfs with missing modules.
Use our own module to call `instmod` without "-c" to avoid checks.