### PR TITLE
dracut: omit AMD/Nvidia GPU drivers and firmwares

### DIFF
--- a/dracut/dracut.conf.d/10-asahi-noextgpu.conf
+++ b/dracut/dracut.conf.d/10-asahi-noextgpu.conf
@@ -1,0 +1,11 @@
+# dracut config fragment to omit external PCIe GPUs
+# as of June 2024 PCIe tunneling over USB4/TB is not supported so it is
+# pointless to include those. Even when PCIe tunneling works PCIe GPUs are
+# probably not suppported and using them as primary display will not be a
+# supported configuration.
+#
+# This saves over 60 MB of firmware files in the initramfs on
+# Fedora-Asahi-Remix (Fedora 40, Kernel 6.9).
+# TODO: omit Xe drivers once their build is enabled on arm64.
+
+omit_drivers+=" amdgpu nouveau radeon "


### PR DESCRIPTION
Decreases initramfs size from 142M to 80M on Fedora-Asahi-Remix.