### PR TITLE
macsmc-battery: persistent charge_control_end_threshold

### DIFF
--- a/macsmc-battery/systemd/macsmc-battery-charge-control-end-threshold.path
+++ b/macsmc-battery/systemd/macsmc-battery-charge-control-end-threshold.path
@@ -1,0 +1,5 @@
+[Unit]
+Description=Monitor charge_control_end_threshold
+
+[Path]
+PathChanged=/sys/class/power_supply/macsmc-battery/charge_control_end_threshold

--- a/macsmc-battery/systemd/macsmc-battery-charge-control-end-threshold.service
+++ b/macsmc-battery/systemd/macsmc-battery-charge-control-end-threshold.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Store current charge_control_end_threshold value persistently
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/sed -e 's/^/CHARGE_CONTROL_END_THRESHOLD=/' /sys/class/power_supply/macsmc-battery/charge_control_end_threshold
+StandardOutput=truncate:/etc/udev/macsmc-battery.conf

--- a/macsmc-battery/udev/93-macsmc-battery-charge-control.rules
+++ b/macsmc-battery/udev/93-macsmc-battery-charge-control.rules
@@ -1,0 +1,12 @@
+# load stored charge_control_end_threshold
+SUBSYSTEM=="power_supply", KERNEL=="macsmc-battery", IMPORT{file}="/etc/udev/$kernel.conf"
+SUBSYSTEM=="power_supply", KERNEL=="macsmc-battery", ENV{CHARGE_CONTROL_END_THRESHOLD}=="[0-9][0-9]", GOTO="set_charge_control_end_threshold"
+
+GOTO="skip_charge_control_end_threshold"
+LABEL="set_charge_control_end_threshold"
+SUBSYSTEM=="power_supply", KERNEL=="macsmc-battery", ATTR{charge_control_end_threshold}="$env{CHARGE_CONTROL_END_THRESHOLD}"
+LABEL="skip_charge_control_end_threshold"
+
+# enable monitoring via a systemd path unit
+SUBSYSTEM=="power_supply", KERNEL=="macsmc-battery", TAG+="systemd"
+SUBSYSTEM=="power_supply", KERNEL=="macsmc-battery", ENV{SYSTEMD_WANTS}="macsmc-battery-charge-control-end-threshold.path"


### PR DESCRIPTION
Add udev rule and systemd units to store charge_control_end_threshold so it can be restored on the next boot.