### PR TITLE
Remove executable bit from the rules file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ install-macsmc-battery: install
 	install -dD $(DESTDIR)$(UDEV_RULES_DIR)
 	install -m0755 -t $(DESTDIR)$(SYSTEMD_UNIT_DIR) macsmc-battery/systemd/macsmc-battery-charge-control-end-threshold.path
 	install -m0755 -t $(DESTDIR)$(SYSTEMD_UNIT_DIR) macsmc-battery/systemd/macsmc-battery-charge-control-end-threshold.service
-	install -m0755 -t $(DESTDIR)$(UDEV_RULES_DIR) macsmc-battery/udev/93-macsmc-battery-charge-control.rules
+	install -m0644 -t $(DESTDIR)$(UDEV_RULES_DIR) macsmc-battery/udev/93-macsmc-battery-charge-control.rules
 
 install-arch: install install-mkinitcpio
 	install -m0755 -t $(DESTDIR)$(BIN_DIR)/ $(BUILD_ARCH_SCRIPTS)


### PR DESCRIPTION
This bit causes systemd to emit the following warning: "Configuration file /usr/lib/udev/rules.d/93-macsmc-battery-charge-control.rules is marked executable. Please remove executable permission bits. Proceeding anyway."