### PR TITLE
update-m1n1: Drop arch specific default DTBS glob pattern

### DIFF
--- a/update-m1n1
+++ b/update-m1n1
@@ -17,8 +17,12 @@ fi
 : ${M1N1:="$SOURCE/m1n1.bin"}
 : ${U_BOOT:="$SOURCE/u-boot-nodtb.bin"}
 : ${TARGET:="$1"}
-: ${DTBS:=$(/bin/ls -d /lib/modules/*-ARCH | sort -rV | head -1)/dtbs/*.dtb}
 : ${CONFIG:=/etc/m1n1.conf}
+
+if [ -z "$DTBS" ]; then
+    warn "ERROR: DTBS config unset or empty, see `/etc/default/update-m1n1`"
+    exit 1
+fi
 
 umount=false
 


### PR DESCRIPTION
The glob pattern for the Apple silicon devicetrees is OS dependent. Do not pretend that's possible to provide a default value and instead error out if it is unset.
Motivated by the addition of devicetrees for non macOS devices which should be excluded from the 2nd stage m1n1 binary.