### PR TITLE
Changed `i2c-apple` to `i2c-pasemi-platform` for initcpio

### DIFF
--- a/initcpio/install/asahi
+++ b/initcpio/install/asahi
@@ -17,7 +17,7 @@ build() {
     map add_module macsmc? macsmc-rtkit?
 
     # For USB
-    map add_module i2c-apple? tps6598x? apple-dart? dwc3? dwc3-of-simple? \
+    map add_module i2c-pasemi-platform? tps6598x? apple-dart? dwc3? dwc3-of-simple? \
         nvmem-apple-efuses? phy-apple-atc? xhci-plat-hcd? xhci-pci? pcie-apple? gpio_macsmc?
 
     # For HID


### PR DESCRIPTION
Just like f444f0aaa7841c02820c67569beff509d5850908

@jannau Can you please clarify my comment here https://github.com/AsahiLinux/asahi-scripts/commit/4acd310cd8c394f9ec2e7e7506d89b7bb3c3ca39#r150493522 - do we need `i2c-apple` here still also? Thanks!

fyi, on alarm:
```
$ modinfo i2c-apple
modinfo: ERROR: Module i2c-apple not found.

$ modinfo i2c-pasemi-platform
name:           i2c_pasemi_platform
filename:       (builtin)
description:    Apple/PASemi SMBus platform driver
author:         Sven Peter <sven@svenpeter.dev>
license:        GPL
file:           drivers/i2c/busses/i2c-pasemi-platform
```