### PR TITLE
update-m1n1: enable/read mitigations option

### DIFF
--- a/update-m1n1
+++ b/update-m1n1
@@ -35,7 +35,7 @@ if [ -e "$CONFIG" ]; then
         case "$line" in
             "") ;;
             \#*) ;;
-            chosen.*=*|display=*)
+            chosen.*=*|display=*|mitigations=*)
                 echo "$line" >> "$m1n1config"
                 info "  Option: $line"
                 ;;


### PR DESCRIPTION
Mitigations option was recently added to m1n1. This change allows the update-m1n1 script to read it. Currently, it only reads chosen and display options.