### PR TITLE
macsmc-battery: write out the config in the service itself

### DIFF
--- a/macsmc-battery/systemd/macsmc-battery-charge-control-end-threshold.service
+++ b/macsmc-battery/systemd/macsmc-battery-charge-control-end-threshold.service
@@ -3,5 +3,4 @@ Description=Store current charge_control_end_threshold value persistently
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/sed -e 's/^/CHARGE_CONTROL_END_THRESHOLD=/' /sys/class/power_supply/macsmc-battery/charge_control_end_threshold
-StandardOutput=truncate:/etc/udev/macsmc-battery.conf
+ExecStart=sh -c 'echo "CHARGE_CONTROL_END_THRESHOLD=$(cat /sys/class/power_supply/macsmc-battery/charge_control_end_threshold)" > /etc/udev/macsmc-battery.conf'


### PR DESCRIPTION
The current logic works, but results in SELinux AVCs because the default policy doesn't allow PID 1 to write out to arbitrary paths in /etc. Change this to do the write within the service itself instead, which should be allowed.

Fixes: #59