### PR TITLE
update-m1n1: make boot.bin replacement atomic

### DIFF
--- a/update-m1n1
+++ b/update-m1n1
@@ -61,7 +61,7 @@ if [ -e "$TARGET" ]; then
     # avoid dependency on diffutils
     SHA512_CUR=$(sha512sum "$TARGET"     | cut -d' ' -f1)
     SHA512_NEW=$(sha512sum "$TARGET.new" | cut -d' ' -f1)
-    [ "$SHA512_CUR" != "$SHA512_NEW" ] && mv -f "$TARGET" "${TARGET}.old"
+    [ "$SHA512_CUR" != "$SHA512_NEW" ] && cp --preserve=timestamps -f "$TARGET" "${TARGET}.old"
 fi
 
 mv -f "${TARGET}.new" "$TARGET"


### PR DESCRIPTION
Previously there was a moment where there where no boot.bin in place. By instead copying the backup and then overwriting boot.bin using mv -f, the replacement should be atomic.