### PR TITLE
dracut: Add apple_spmi_nvmem module

### DIFF
--- a/dracut/modules.d/91kernel-modules-asahi/module-setup.sh
+++ b/dracut/modules.d/91kernel-modules-asahi/module-setup.sh
@@ -30,7 +30,9 @@ installkernel() {
         gpio_macsmc
 
     # For RTC
-    hostonly='' instmods rtc-macsmc simple-mfd-spmi spmi-apple-controller nvmem_spmi_mfd
+    hostonly='' instmods rtc-macsmc spmi-apple-controller apple_nvmem_spmi
+    # pre upstream spmi nvmem, delete with 6.16 + 1 release
+    hostonly='' instmods simple-mfd-spmi nvmem_spmi_mfd
 
     # For HID
     hostonly='' instmods spi-apple spi-hid-apple spi-hid-apple-of


### PR DESCRIPTION
The SPMI nvmem support was merged as apple_spmi_nvmem for v6.16 and Asahi's v6.15 based downstream tree pick those patches up. Add the module the dracut config to ensure it ends up in the initramfs. Keep the old modules until v6.16++ is released to ensure compatibility with older kernels for a while.