### PR TITLE
asahi-diagnose: set pipefail in check_macaudio_profile

### DIFF
--- a/asahi-diagnose
+++ b/asahi-diagnose
@@ -72,9 +72,11 @@ EOF
 # Check pipewire profile
 check_macaudio_profile() {
     local profile_config="${HOME}/.local/state/wireplumber/default-profile"
+    set -o pipefail
     [ -e  ${profile_config} ] \
     && sed -ne 's/^alsa_card.platform-sound=// p' ${profile_config} | grep . \
     || echo "Default"
+    set +o pipefail
 }
 macaudio_profile=$(check_macaudio_profile)
 


### PR DESCRIPTION
`grep | sed || echo` will never run `echo` unless pipefail is set. As a result, asahi-diagnose reports non-existent issues with audio.