### PR TITLE
update-m1n1: Expand $DTBS if it is a directory

### DIFF
--- a/update-m1n1
+++ b/update-m1n1
@@ -24,6 +24,12 @@ if [ -z "$DTBS" ]; then
     exit 1
 fi
 
+# If ${DTBS} is a directory expand it to include dtbs from all Apple silicon
+# macs.
+if [ -d "$DTBS" ]; then
+    DTBS="${DTBS}/apple/t6*.dtb ${DTBS}/apple/t81*.dtb"
+fi
+
 umount=false
 
 m1n1config=/run/m1n1.conf


### PR DESCRIPTION
Allows limiting the included devices to Apple silicon macs now that the kernel has device-trees for iphones, ipads and T2 macs as well. Avoids having each distribution to modify their default update-m1n1 configuration for this.