### PR TITLE
dracut: asahi-firmware: Configure the /lib/firmware/vendor path

### DIFF
--- a/dracut/modules.d/99asahi-firmware/install-asahi-firmware.sh
+++ b/dracut/modules.d/99asahi-firmware/install-asahi-firmware.sh
@@ -4,9 +4,18 @@
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 info ":: Asahi: Installing vendor firmware to root filesystem..."
+
 if [ ! -d /sysroot/lib/firmware/vendor ]; then
     warn ":: Asahi: Vendor firmware directory missing on the root filesystem!"
     return 1
 fi
+
+if [ -e /sys/module/firmware_class/parameters/path ]; then
+    echo -n /lib/firmware/vendor > /sys/module/firmware_class/parameters/path
+else
+    warn ":: Asahi: Vendor firmware directory unable to be configured!"
+    return 1
+fi
+
 mount -t tmpfs -o mode=0755 vendorfw /sysroot/lib/firmware/vendor
 cp -a /vendorfw/* /vendorfw/.vendorfw.manifest /sysroot/lib/firmware/vendor


### PR DESCRIPTION
This enables the running kernel to know it can load firmware from the path we install firmware data to after copying the staged data from the ESP location (which itself was installed there by the installer).